### PR TITLE
Add translation for 'redirectToNextMeeting'

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changelog
 4.1.17 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Add translation for `redirectToNextMeeting` option.
 
 
 4.1.16 (2020-06-24)

--- a/src/imio/pm/locales/locales/PloneMeeting.pot
+++ b/src/imio/pm/locales/locales/PloneMeeting.pot
@@ -1828,8 +1828,16 @@ msgstr ""
 msgid "PloneMeeting_label_yearlyInitMeetingNumber"
 msgstr ""
 
+#. Default: "On login redirects to the next meeting?"
+msgid "PloneMeeting_label_redirectToNextMeeting"
+msgstr ""
+
 #. Default: "If you check this box, the automatically incremented meeting number will be set to zero every year. It means that the first meeting of every year will get number one."
 msgid "yearly_init_meeting_nb_descr"
+msgstr ""
+
+#. Default: "If you check this box, after the user logs in or arrives on an instance, it will be redirected to the next meeting if there is one."
+msgid "redirect_to_next_meeting_desc"
 msgstr ""
 
 #. Default: "Within every meeting configuration, meetings are numbered sequentially."

--- a/src/imio/pm/locales/locales/de/LC_MESSAGES/PloneMeeting.po
+++ b/src/imio/pm/locales/locales/de/LC_MESSAGES/PloneMeeting.po
@@ -1594,6 +1594,10 @@ msgstr "Stati der TOP für welche die Speicherung der History aktiviert ist"
 msgid "PloneMeeting_label_recordMeetingHistoryStates"
 msgstr ""
 
+#. Default: "On login redirects to the next meeting?"
+msgid "PloneMeeting_label_redirectToNextMeeting"
+msgstr ""
+
 #. Default: "Remove annexes previews on meeting closure"
 msgid "PloneMeeting_label_removeAnnexesPreviewsOnMeetingClosure"
 msgstr ""
@@ -5155,6 +5159,10 @@ msgstr "Hier werden vorkonfigurierte TOP verwaltet. Diese können als Vorlage f�
 
 #. Default: "${assembly} ${assembly_edit} and ${signatures} ${signatures_edit}"
 msgid "redefinable_assembly_and_signatures"
+msgstr ""
+
+#. Default: "If you check this box, after the user logs in or arrives on an instance, it will be redirected to the next meeting if there is one."
+msgid "redirect_to_next_meeting_desc"
 msgstr ""
 
 #. Default: "Refresh vote values"

--- a/src/imio/pm/locales/locales/en/LC_MESSAGES/PloneMeeting.po
+++ b/src/imio/pm/locales/locales/en/LC_MESSAGES/PloneMeeting.po
@@ -1589,6 +1589,10 @@ msgstr "Item states into which events will be recorded in item's history"
 msgid "PloneMeeting_label_recordMeetingHistoryStates"
 msgstr "Meeting states into which events will be recorded in meeting's history"
 
+#. Default: "On login redirects to the next meeting?"
+msgid "PloneMeeting_label_redirectToNextMeeting"
+msgstr ""
+
 #. Default: "Remove annexes previews on meeting closure"
 msgid "PloneMeeting_label_removeAnnexesPreviewsOnMeetingClosure"
 msgstr "Remove annexes previews on meeting closure"
@@ -5083,6 +5087,10 @@ msgstr "Recurring items are items that will be automatically added to a meeting 
 #. Default: "${assembly} ${assembly_edit} and ${signatures} ${signatures_edit}"
 msgid "redefinable_assembly_and_signatures"
 msgstr "${assembly} ${assembly_edit} and ${signatures} ${signatures_edit}"
+
+#. Default: "If you check this box, after the user logs in or arrives on an instance, it will be redirected to the next meeting if there is one."
+msgid "redirect_to_next_meeting_desc"
+msgstr ""
 
 #. Default: "Refresh vote values"
 msgid "refresh_votes"

--- a/src/imio/pm/locales/locales/es/LC_MESSAGES/PloneMeeting.po
+++ b/src/imio/pm/locales/locales/es/LC_MESSAGES/PloneMeeting.po
@@ -1600,6 +1600,10 @@ msgstr "Los estados de temas en los que los eventos serán registrados en el his
 msgid "PloneMeeting_label_recordMeetingHistoryStates"
 msgstr "Los estados de reunión en los cuales los eventos serán registrados en el historial de la reunión"
 
+#. Default: "On login redirects to the next meeting?"
+msgid "PloneMeeting_label_redirectToNextMeeting"
+msgstr ""
+
 #. Default: "Remove annexes previews on meeting closure"
 msgid "PloneMeeting_label_removeAnnexesPreviewsOnMeetingClosure"
 msgstr ""
@@ -5187,6 +5191,10 @@ msgstr "Usted puede manejar aquí temas predefinidos que servirán, para diferen
 
 #. Default: "${assembly} ${assembly_edit} and ${signatures} ${signatures_edit}"
 msgid "redefinable_assembly_and_signatures"
+msgstr ""
+
+#. Default: "If you check this box, after the user logs in or arrives on an instance, it will be redirected to the next meeting if there is one."
+msgid "redirect_to_next_meeting_desc"
 msgstr ""
 
 #. Default: "Refresh vote values"

--- a/src/imio/pm/locales/locales/fr/LC_MESSAGES/PloneMeeting.po
+++ b/src/imio/pm/locales/locales/fr/LC_MESSAGES/PloneMeeting.po
@@ -1589,6 +1589,10 @@ msgstr "États des points dans lesquels l'historisation est active"
 msgid "PloneMeeting_label_recordMeetingHistoryStates"
 msgstr "États des séances dans lesquels l'historisation est active"
 
+#. Default: "On login redirects to the next meeting?"
+msgid "PloneMeeting_label_redirectToNextMeeting"
+msgstr "A la connexion redirige vers la prochaine séance?"
+
 #. Default: "Remove annexes previews on meeting closure"
 msgid "PloneMeeting_label_removeAnnexesPreviewsOnMeetingClosure"
 msgstr "Supprimer les prévisualisations des annexes lors de la clôture de la séance"
@@ -5082,6 +5086,10 @@ msgstr "Les points récurrents sont des points automatiquement ajoutés à une s
 #. Default: "${assembly} ${assembly_edit} and ${signatures} ${signatures_edit}"
 msgid "redefinable_assembly_and_signatures"
 msgstr "${assembly} ${assembly_edit} et ${signatures} ${signatures_edit}"
+
+#. Default: "If you check this box, after the user logs in or arrives on an instance, it will be redirected to the next meeting if there is one."
+msgid "redirect_to_next_meeting_desc"
+msgstr "Si vous cochez cette case, après que l'utilisateur ce soit connecté ou arrive sur un instance, celui-ci sera redirigé vers la prochaine séance si il y en a une."
 
 #. Default: "Refresh vote values"
 msgid "refresh_votes"

--- a/src/imio/pm/locales/locales/fr/LC_MESSAGES/PloneMeeting.po
+++ b/src/imio/pm/locales/locales/fr/LC_MESSAGES/PloneMeeting.po
@@ -5108,7 +5108,7 @@ msgstr "${assembly} ${assembly_edit} et ${signatures} ${signatures_edit}"
 
 #. Default: "By default, once connected, user is redirected to a dashboard displaying items.  Select here profiles that will be redirected to the next meeting if it exists."
 msgid "redirect_to_next_meeting_descr"
-msgstr "Par défaut, une fois connecté, les utilisateurs sont redirigés vers une recherche de points (mes points, tous les points, ...).  Sélectionnez les profiles qui seront redirigés vers la prochaine séance s'il y en a une."
+msgstr "Par défaut, une fois connecté, les utilisateurs sont redirigés vers une recherche de points (mes points, tous les points, ...).  Sélectionnez les profils qui seront redirigés vers la prochaine séance s'il y en a une."
 
 #. Default: "Refresh vote values"
 msgid "refresh_votes"

--- a/src/imio/pm/locales/locales/nl/LC_MESSAGES/PloneMeeting.po
+++ b/src/imio/pm/locales/locales/nl/LC_MESSAGES/PloneMeeting.po
@@ -1594,6 +1594,10 @@ msgstr ""
 msgid "PloneMeeting_label_recordMeetingHistoryStates"
 msgstr ""
 
+#. Default: "On login redirects to the next meeting?"
+msgid "PloneMeeting_label_redirectToNextMeeting"
+msgstr ""
+
 #. Default: "Remove annexes previews on meeting closure"
 msgid "PloneMeeting_label_removeAnnexesPreviewsOnMeetingClosure"
 msgstr ""
@@ -5118,6 +5122,10 @@ msgstr "You manage here predefined items that will serve, for different purposes
 
 #. Default: "${assembly} ${assembly_edit} and ${signatures} ${signatures_edit}"
 msgid "redefinable_assembly_and_signatures"
+msgstr ""
+
+#. Default: "If you check this box, after the user logs in or arrives on an instance, it will be redirected to the next meeting if there is one."
+msgid "redirect_to_next_meeting_desc"
 msgstr ""
 
 #. Default: "Refresh vote values"


### PR DESCRIPTION
This PR is related to the addition of the redirectToNextMeeting option in Product.Plonemeeting.