### PR TITLE
Completed mail notifications translations `item_state_changed_default_mail_subject`...

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,10 @@ Changelog
   [gbastien]
 - Fixed typo in french translation of `PloneMeeting_label_selectableAdviserUsers`.
   [gbastien]
+- Completed mail notifications translations `item_state_changed_default_mail_subject`
+  and `item_state_changed_default_mail_body` to include transition infos
+  (title, actor, comments) now that it is available in received `translationMapping`.
+  [gbastien]
 
 4.2b10 (2021-09-09)
 -------------------

--- a/src/imio/pm/locales/locales/PloneMeeting.pot
+++ b/src/imio/pm/locales/locales/PloneMeeting.pot
@@ -3151,15 +3151,11 @@ msgid "searchallmeetings"
 msgstr ""
 
 # Mails (item-related)
-# Default translation for mails sent upon item transition
-# This default is used if no accurate translation can be found. We will try for example to translate
-# item_state_changed_decided_mail_subject, if not found (by default), we use item_state_changed_default_mail_subject.
-# This way we can have specific mail message for each different transition
-#. Default: "${meetingConfigTitle} - Item in state \"${itemState}\" - ${itemTitle}"
+#. Default: "${meetingConfigTitle} - Item in state \"${itemState}\" (following \"${transitionTitle}\") - ${itemTitle}"
 msgid "item_state_changed_default_mail_subject"
 msgstr ""
 
-#. Default: "The item is entitled \"${itemTitle}\". You can access this item here: ${objectUrl}."
+#. Default: "The item is entitled \"${itemTitle}\". You can access this item here: ${objectUrl}.\n\nAction was done by \"${transitionActor}\".\nComments: ${transitionComments}."
 msgid "item_state_changed_default_mail_body"
 msgstr ""
 

--- a/src/imio/pm/locales/locales/de/LC_MESSAGES/PloneMeeting.po
+++ b/src/imio/pm/locales/locales/de/LC_MESSAGES/PloneMeeting.po
@@ -4319,7 +4319,7 @@ msgstr "Spezifisch für diesen TOP:"
 msgid "item_state"
 msgstr "Status"
 
-#. Default: "The item is entitled \"${itemTitle}\". You can access this item here: ${objectUrl}."
+#. Default: "The item is entitled \"${itemTitle}\". You can access this item here: ${objectUrl}.\n\nAction was done by \"${transitionActor}\".\nComments: ${transitionComments}."
 msgid "item_state_changed_default_mail_body"
 msgstr ""
 
@@ -4328,7 +4328,7 @@ msgstr ""
 # This default is used if no accurate translation can be found. We will try for example to translate
 # item_state_changed_decided_mail_subject, if not found (by default), we use item_state_changed_default_mail_subject.
 # This way we can have specific mail message for each different transition
-#. Default: "${meetingConfigTitle} - Item in state \"${itemState}\" - ${itemTitle}"
+#. Default: "${meetingConfigTitle} - Item in state \"${itemState}\" (following \"${transitionTitle}\") - ${itemTitle}"
 msgid "item_state_changed_default_mail_subject"
 msgstr ""
 

--- a/src/imio/pm/locales/locales/en/LC_MESSAGES/PloneMeeting.po
+++ b/src/imio/pm/locales/locales/en/LC_MESSAGES/PloneMeeting.po
@@ -4271,18 +4271,14 @@ msgstr "Specifically, for this item:"
 msgid "item_state"
 msgstr "State"
 
-#. Default: "The item is entitled \"${itemTitle}\". You can access this item here: ${objectUrl}."
+#. Default: "The item is entitled \"${itemTitle}\". You can access this item here: ${objectUrl}.\n\nAction was done by \"${transitionActor}\".\nComments: ${transitionComments}."
 msgid "item_state_changed_default_mail_body"
-msgstr "The item is entitled \"${itemTitle}\". You can access this item here: ${objectUrl}."
+msgstr "The item is entitled \"${itemTitle}\". You can access this item here: ${objectUrl}.\n\nAction was done by \"${transitionActor}\".\nComments: ${transitionComments}."
 
 # Mails (item-related)
-# Default translation for mails sent upon item transition
-# This default is used if no accurate translation can be found. We will try for example to translate
-# item_state_changed_decided_mail_subject, if not found (by default), we use item_state_changed_default_mail_subject.
-# This way we can have specific mail message for each different transition
-#. Default: "${meetingConfigTitle} - Item in state \"${itemState}\" - ${itemTitle}"
+#. Default: "${meetingConfigTitle} - Item in state \"${itemState}\" (following \"${transitionTitle}\") - ${itemTitle}"
 msgid "item_state_changed_default_mail_subject"
-msgstr "${meetingConfigTitle} - Item in state \"${itemState}\" - ${itemTitle}"
+msgstr "${meetingConfigTitle} - Item in state \"${itemState}\" (following \"${transitionTitle}\") - ${itemTitle}"
 
 #. Default: "Item templates will be available to users creating new items in the application."
 msgid "item_templates_descr"

--- a/src/imio/pm/locales/locales/es/LC_MESSAGES/PloneMeeting.po
+++ b/src/imio/pm/locales/locales/es/LC_MESSAGES/PloneMeeting.po
@@ -4346,7 +4346,7 @@ msgstr "Especialmente, para este tema:"
 msgid "item_state"
 msgstr "Estado"
 
-#. Default: "The item is entitled \"${itemTitle}\". You can access this item here: ${objectUrl}."
+#. Default: "The item is entitled \"${itemTitle}\". You can access this item here: ${objectUrl}.\n\nAction was done by \"${transitionActor}\".\nComments: ${transitionComments}."
 #, fuzzy
 msgid "item_state_changed_default_mail_body"
 msgstr "Usted puede consultar este tema en ${objectUrl}."
@@ -4356,7 +4356,7 @@ msgstr "Usted puede consultar este tema en ${objectUrl}."
 # This default is used if no accurate translation can be found. We will try for example to translate
 # item_state_changed_decided_mail_subject, if not found (by default), we use item_state_changed_default_mail_subject.
 # This way we can have specific mail message for each different transition
-#. Default: "${meetingConfigTitle} - Item in state \"${itemState}\" - ${itemTitle}"
+#. Default: "${meetingConfigTitle} - Item in state \"${itemState}\" (following \"${transitionTitle}\") - ${itemTitle}"
 #, fuzzy
 msgid "item_state_changed_default_mail_subject"
 msgstr "${meetingConfigTitle} - ${itemTitle} - Este tema esta ahora en el estado '${itemState}'."

--- a/src/imio/pm/locales/locales/fr/LC_MESSAGES/PloneMeeting.po
+++ b/src/imio/pm/locales/locales/fr/LC_MESSAGES/PloneMeeting.po
@@ -2171,7 +2171,7 @@ msgstr "Ajouter plusieurs annexes (après décision)"
 
 #. Default: "You had an advice to give for \"${group_name} (${delay_label})\".  Limit date is ${limit_date}, delay is now expired.  You can access this item here: ${objectUrl}."
 msgid "adviceDelayExpired_mail_body"
-msgstr "Le délai pour rendre l'avis \"${group_name} (${delay_label})\" est expiré, la date limite était le ${limit_date}. Accédez au point ici: ${objectUrl}."
+msgstr "Le délai pour rendre l'avis \"${group_name} (${delay_label})\" est expiré, la date limite était le ${limit_date}.\nAccédez au point ici: ${objectUrl}."
 
 #. Default: "${meetingConfigTitle} - Advice delay expired - ${itemTitle}"
 msgid "adviceDelayExpired_mail_subject"
@@ -2179,7 +2179,7 @@ msgstr "${meetingConfigTitle} - Délai expiré pour rendre un avis - ${itemTitle
 
 #. Default: "You have an advice to give for \"${group_name} (${delay_label})\".  Limit date is ${limit_date) (in ${left_delay} day(s)).  You can access this item here: ${objectUrl}."
 msgid "adviceDelayWarning_mail_body"
-msgstr "La date limite pour rendre l'avis \"${group_name} (${delay_label})\" est le ${limit_date} (dans ${left_delay} jour(s)). Accédez au point ici: ${objectUrl}."
+msgstr "La date limite pour rendre l'avis \"${group_name} (${delay_label})\" est le ${limit_date} (dans ${left_delay} jour(s)).\nAccédez au point ici: ${objectUrl}."
 
 #. Default: "${meetingConfigTitle} - Warning advice delay expiration - ${itemTitle}"
 msgid "adviceDelayWarning_mail_subject"
@@ -2187,7 +2187,7 @@ msgstr "${meetingConfigTitle} - Avertissement expiration délai pour rendre un a
 
 #. Default: "The item is entitled \"${itemTitle}\". You can access this item here: ${objectUrl}."
 msgid "adviceEdited_mail_body"
-msgstr "L'objet du point est \"${itemTitle}\". Accédez au point ici: ${objectUrl}."
+msgstr "L'objet du point est \"${itemTitle}\".\nAccédez au point ici: ${objectUrl}."
 
 #. Default: "${meetingConfigTitle} - An advice has been added or modified  - ${itemTitle}"
 msgid "adviceEdited_mail_subject"
@@ -2195,7 +2195,7 @@ msgstr "${meetingConfigTitle} - Un avis a été rendu ou modifié - ${itemTitle}
 
 #. Default: "You can consult this item at ${objectUrl}. You advice is now back in the menu with a question mark icon. You can edit it again by clicking on the pen besides it."
 msgid "adviceInvalidated_mail_body"
-msgstr "Votre avis est de retour dans le menu avec un point d'interrogation. Vous pouvez l'éditer à nouveau en cliquant sur le crayon à sa droite. Accédez à ce point ici: ${objectUrl}."
+msgstr "Votre avis est de retour dans le menu avec un point d'interrogation. Vous pouvez l'éditer à nouveau en cliquant sur le crayon à sa droite.\nAccédez au point ici: ${objectUrl}."
 
 #. Default: "${meetingConfigTitle} - One or your advices has been invalidated - ${itemTitle}"
 msgid "adviceInvalidated_mail_subject"
@@ -2203,7 +2203,7 @@ msgstr "${meetingConfigTitle} - Un avis que vous avez rendu a été invalidé - 
 
 #. Default: "The item is entitled \"${itemTitle}\". You can access this item here: ${objectUrl}."
 msgid "adviceToGiveByUser_mail_body"
-msgstr "L'objet du point est \"${itemTitle}\". Accédez au point ici: ${objectUrl}."
+msgstr "L'objet du point est \"${itemTitle}\".\nAccédez au point ici: ${objectUrl}."
 
 #. Default: "${meetingConfigTitle} - Your advice is requested - ${itemTitle}"
 msgid "adviceToGiveByUser_mail_subject"
@@ -2211,7 +2211,7 @@ msgstr "${meetingConfigTitle} - Votre avis est demandé - ${itemTitle}"
 
 #. Default: "The item is entitled \"${itemTitle}\". You can access this item here: ${objectUrl}."
 msgid "adviceToGive_mail_body"
-msgstr "L'objet du point est \"${itemTitle}\". Accédez au point ici: ${objectUrl}."
+msgstr "L'objet du point est \"${itemTitle}\".\nAccédez au point ici: ${objectUrl}."
 
 #. Default: "${meetingConfigTitle} - Your advice is requested - ${itemTitle}"
 msgid "adviceToGive_mail_subject"
@@ -2367,7 +2367,7 @@ msgstr ", description"
 
 #. Default: "An annex has been added to the item \"${itemTitle}\" that was already presented to the meeting.  You can access this item here: ${objectUrl}."
 msgid "annexAdded_mail_body"
-msgstr "Une annexe a été ajoutée au point \"${itemTitle}\" alors qu'il était déjà présenté dans une séance. Accédez à ce point ici: ${objectUrl}."
+msgstr "Une annexe a été ajoutée au point \"${itemTitle}\" alors qu'il était déjà présenté dans une séance.\nAccédez au point ici: ${objectUrl}."
 
 #. Default: "${meetingConfigTitle} - ${meetingTitle} - An annex was just added to an item."
 msgid "annexAdded_mail_subject"
@@ -2495,7 +2495,7 @@ msgstr "Comme point récurrent"
 
 #. Default: "The item is entitled \"${itemNumber} - ${itemTitle}\". You can access this item here: ${objectUrl}."
 msgid "askDiscussItem_mail_body"
-msgstr "L'objet du point est \"${itemNumber} - ${itemTitle}\". Accédez à ce point ici: ${objectUrl}."
+msgstr "L'objet du point est \"${itemNumber} - ${itemTitle}\".\nAccédez au point ici: ${objectUrl}."
 
 #. Default: "${meetingConfigTitle} - ${meetingTitle} - ${user}, belonging to group(s) ${groups}, would like to discuss an item."
 msgid "askDiscussItem_mail_subject"
@@ -2988,7 +2988,7 @@ msgstr "Sélectionnez ici les éléments à garder lors de l'envoi d'un point ve
 
 #. Default: "The item is entitled \"${itemTitle}\". You can access this item here: ${objectUrl}."
 msgid "copyGroups_mail_body"
-msgstr "L'objet du point est \"${itemTitle}\". Accédez au point ici: ${objectUrl}."
+msgstr "L'objet du point est \"${itemTitle}\".\nAccédez au point ici: ${objectUrl}."
 
 #. Default: "${meetingConfigTitle} - You have been carbon copied - ${itemTitle}"
 msgid "copyGroups_mail_subject"
@@ -4023,7 +4023,7 @@ msgstr "Les états sélectionnés ici doivent reprendre au moins tous les états
 
 #. Default: "The item is entitled \"${itemTitle}\". You can access this item here: ${objectUrl}."
 msgid "itemClonedToThisMC_mail_body"
-msgstr "L'objet du point est \"${itemTitle}\". Accédez au point ici: ${objectUrl}."
+msgstr "L'objet du point est \"${itemTitle}\".\nAccédez au point ici: ${objectUrl}."
 
 #. Default: "${meetingConfigTitle} - Item received from ${originMeetingConfigTitle} - ${itemTitle}"
 msgid "itemClonedToThisMC_mail_subject"
@@ -4051,7 +4051,7 @@ msgstr "Les séances qui seront dans ces états pourront être sélectionnées c
 
 #. Default: "This meeting may still be under construction and is potentially inaccessible.  The item is entitled \"${itemTitle}\". You can access this item here: ${objectUrl}."
 msgid "itemPresented_mail_body"
-msgstr "La séance est peut-être encore en cours d'élaboration et donc inaccessible pour l'instant. L'objet du point est \"${itemTitle}\". Accédez au point ici: ${objectUrl}."
+msgstr "La séance est peut-être encore en cours d'élaboration et donc inaccessible pour l'instant. L'objet du point est \"${itemTitle}\".\nAccédez au point ici: ${objectUrl}."
 
 #. Default: "${meetingConfigTitle} - Item has been inserted into a meeting - ${itemTitle}"
 msgid "itemPresented_mail_subject"
@@ -4059,7 +4059,7 @@ msgstr "${meetingConfigTitle} - Point inséré dans une séance - ${itemTitle}"
 
 #. Default: "The item is entitled \"${itemTitle}\". You can access this item here: ${objectUrl}."
 msgid "itemUnpresented_mail_body"
-msgstr "L'objet du point est \"${itemTitle}\". Accédez au point ici: ${objectUrl}."
+msgstr "L'objet du point est \"${itemTitle}\".\nAccédez au point ici: ${objectUrl}."
 
 #. Default: "${meetingConfigTitle} - Item was removed from meeting - ${itemTitle}"
 msgid "itemUnpresented_mail_subject"
@@ -4269,18 +4269,18 @@ msgstr "Pour ce point en particulier:"
 msgid "item_state"
 msgstr "État"
 
-#. Default: "The item is entitled \"${itemTitle}\". You can access this item here: ${objectUrl}."
+#. Default: "The item is entitled \"${itemTitle}\". You can access this item here: ${objectUrl}.\n\nAction was done by \"${transitionActor}\".\nComments: ${transitionComments}."
 msgid "item_state_changed_default_mail_body"
-msgstr "L'objet du point est \"${itemTitle}\". Accédez au point ici: ${objectUrl}."
+msgstr ""
+"L'objet du point est \"${itemTitle}\".\nAccédez au point ici: ${objectUrl}.\n"
+"\n"
+"Action exécutée par \"${transitionActor}\".\n"
+"Commentaire: ${transitionComments}."
 
 # Mails (item-related)
-# Default translation for mails sent upon item transition
-# This default is used if no accurate translation can be found. We will try for example to translate
-# item_state_changed_decided_mail_subject, if not found (by default), we use item_state_changed_default_mail_subject.
-# This way we can have specific mail message for each different transition
-#. Default: "${meetingConfigTitle} - Item in state \"${itemState}\" - ${itemTitle}"
+#. Default: "${meetingConfigTitle} - Item in state \"${itemState}\" (following \"${transitionTitle}\") - ${itemTitle}"
 msgid "item_state_changed_default_mail_subject"
-msgstr "${meetingConfigTitle} - Point dans l'état \"${itemState}\" - ${itemTitle}"
+msgstr "${meetingConfigTitle} - Point \"${itemState}\" (action \"${transitionTitle}\") - ${itemTitle}"
 
 #. Default: "Item templates will be available to users creating new items in the application."
 msgid "item_templates_descr"
@@ -4416,7 +4416,7 @@ msgstr "Point supplémentaire (ou en urgence)"
 
 #. Default: "The item is entitled \"${itemTitle}\". You can access this item here: ${objectUrl}."
 msgid "lateItem_mail_body"
-msgstr "L'objet du point est \"${itemTitle}\". Accédez au point ici: ${objectUrl}."
+msgstr "L'objet du point est \"${itemTitle}\".\nAccédez au point ici: ${objectUrl}."
 
 # Mails (item-related)
 #. Default: "${meetingConfigTitle} - A \"late\" item has been validated."
@@ -5392,7 +5392,7 @@ msgstr "Super observateurs restreints"
 
 #. Default: "The item is entitled \"${itemTitle}\". You can access this item here: ${objectUrl}."
 msgid "returnedToMeetingManagers_mail_body"
-msgstr "L'objet du point est \"${itemTitle}\". Accédez au point ici: ${objectUrl}."
+msgstr "L'objet du point est \"${itemTitle}\".\nAccédez au point ici: ${objectUrl}."
 
 #. Default: "${meetingConfigTitle} - Item corrected and sent back to the meeting managers - ${itemTitle}"
 msgid "returnedToMeetingManagers_mail_subject"
@@ -5400,7 +5400,7 @@ msgstr "${meetingConfigTitle} - Point corrigé renvoyé aux gestionnaires de sé
 
 #. Default: "The item is entitled \"${itemTitle}\". You can access this item here: ${objectUrl}."
 msgid "returnedToProposingGroup_mail_body"
-msgstr "L'objet du point est \"${itemTitle}\". Accédez au point ici: ${objectUrl}."
+msgstr "L'objet du point est \"${itemTitle}\".\nAccédez au point ici: ${objectUrl}."
 
 #. Default: "${meetingConfigTitle} - Item sent back to you for corrections - ${itemTitle}"
 msgid "returnedToProposingGroup_mail_subject"

--- a/src/imio/pm/locales/locales/nl/LC_MESSAGES/PloneMeeting.po
+++ b/src/imio/pm/locales/locales/nl/LC_MESSAGES/PloneMeeting.po
@@ -4286,7 +4286,7 @@ msgstr ""
 msgid "item_state"
 msgstr "Staat"
 
-#. Default: "The item is entitled \"${itemTitle}\". You can access this item here: ${objectUrl}."
+#. Default: "The item is entitled \"${itemTitle}\". You can access this item here: ${objectUrl}.\n\nAction was done by \"${transitionActor}\".\nComments: ${transitionComments}."
 msgid "item_state_changed_default_mail_body"
 msgstr ""
 
@@ -4295,7 +4295,7 @@ msgstr ""
 # This default is used if no accurate translation can be found. We will try for example to translate
 # item_state_changed_decided_mail_subject, if not found (by default), we use item_state_changed_default_mail_subject.
 # This way we can have specific mail message for each different transition
-#. Default: "${meetingConfigTitle} - Item in state \"${itemState}\" - ${itemTitle}"
+#. Default: "${meetingConfigTitle} - Item in state \"${itemState}\" (following \"${transitionTitle}\") - ${itemTitle}"
 msgid "item_state_changed_default_mail_subject"
 msgstr ""
 


### PR DESCRIPTION
... and `item_state_changed_default_mail_body` to include transition infos (title, actor, comments) now that it is available in received `translationMapping`.

See #MPMSPII-4