### PR TITLE
Removed translations related to field `MeetingConfig.transitionsForPresentingAnItem` that was removed.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,9 @@ Changelog
 
 - Added translations related to `attendees order by item`.
   [gbastien]
+- Removed translations related to field
+  `MeetingConfig.transitionsForPresentingAnItem` that was removed.
+  [gbastien]
 
 4.2b28 (2022-07-01)
 -------------------

--- a/src/imio/pm/locales/locales/PloneMeeting.pot
+++ b/src/imio/pm/locales/locales/PloneMeeting.pot
@@ -2068,14 +2068,6 @@ msgstr ""
 msgid "transitions_to_confirm_descr"
 msgstr ""
 
-#. Default: "Transitions for presenting an item"
-msgid "PloneMeeting_label_transitionsForPresentingAnItem"
-msgstr ""
-
-#. Default: "Set here the sequence of transitions in the right order to be triggered on an item for it to be presented to a meeting.  The first transition is the one that starts from the initial state and the last transition should be \"present\".  This is used in several functionnalities like recurring items or items sent to another meeting config that need to be presented automatically."
-msgid "transitions_for_presenting_an_item_descr"
-msgstr ""
-
 #. Default: "Notifications \"${conflicting_notifications}\" may not be selected together."
 msgid "mail_item_events_conflicts"
 msgstr ""
@@ -4244,22 +4236,6 @@ msgstr ""
 
 #. Default: "This transition was triggered automatically while this item was sent to this meeting config."
 msgid "transition_auto_triggered_item_sent_to_this_config"
-msgstr ""
-
-#. Default: "Please respect order of transitions sequence to present an item, the first given transition is not a transition leaving the item workflow initial state."
-msgid "first_transition_must_leave_wf_initial_state"
-msgstr ""
-
-#. Default: "Please respect order of transitions sequence to present an item, the first given transition is not a transition leaving the item workflow initial state."
-msgid "first_transition_must_leave_wf_initial_state"
-msgstr ""
-
-#. Default: "Please respect order of transitions sequence to present an item, the given sequence of transitions is wrong."
-msgid "given_wf_path_does_not_lead_to_present"
-msgstr ""
-
-#. Default: "Please respect order of transitions sequence to present an item, the given sequence is not resulting in the \"presented\" state."
-msgid "last_transition_must_result_in_presented_state"
 msgstr ""
 
 #. Default: "No history informations are available for now."

--- a/src/imio/pm/locales/locales/de/LC_MESSAGES/PloneMeeting.po
+++ b/src/imio/pm/locales/locales/de/LC_MESSAGES/PloneMeeting.po
@@ -1747,10 +1747,6 @@ msgstr ""
 msgid "PloneMeeting_label_toPrint"
 msgstr ""
 
-#. Default: "Transitions for presenting an item"
-msgid "PloneMeeting_label_transitionsForPresentingAnItem"
-msgstr ""
-
 #. Default: "Transitions that will reinitialize advice delays"
 msgid "PloneMeeting_label_transitionsReinitializingDelays"
 msgstr ""
@@ -3724,10 +3720,6 @@ msgstr "Bitte wählen Sie eine Datei aus indem Sie auf den 'Durchsuchen'-Knopf k
 msgid "first_linked_vote_used_vote_values_descr"
 msgstr ""
 
-#. Default: "Please respect order of transitions sequence to present an item, the first given transition is not a transition leaving the item workflow initial state."
-msgid "first_transition_must_leave_wf_initial_state"
-msgstr ""
-
 #. Default: "In the application folder of every member, a sub-folder is created for each meeting configuration. The name of this sub-folder is defined here."
 #, fuzzy
 msgid "folder_title_descr"
@@ -3762,10 +3754,6 @@ msgstr "In Plone kann man standardmäßig nur einen 'Admin' definieren (E-Mail u
 #, fuzzy
 msgid "functional_admin_name_descr"
 msgstr "Schreiben Sie hier den Kompletten Namen des funktionellen Administrators. Wenn definiert, steht er in dem 'Vom' Teil der eMail Benachrichtigungen die durch PloneMeeting verschickt werden (die vorherigen Felder müssen dafür korrekt ausgefüllt sein)."
-
-#. Default: "Please respect order of transitions sequence to present an item, the given sequence of transitions is wrong."
-msgid "given_wf_path_does_not_lead_to_present"
-msgstr ""
 
 #. Default: "Back to the first elements"
 msgid "goto_first"
@@ -4593,10 +4581,6 @@ msgstr "Erweiterte Suche"
 #. Default: "Within every meeting configuration, meetings are numbered sequentially."
 msgid "last_meeting_number_descr"
 msgstr "In jeder Sitzungs-Konfiguration werden Sutzungen mit Hilfe einer fortlaufenden Nummer nummeriert."
-
-#. Default: "Please respect order of transitions sequence to present an item, the given sequence is not resulting in the \"presented\" state."
-msgid "last_transition_must_result_in_presented_state"
-msgstr ""
 
 #. Default: "Late item"
 msgid "late"
@@ -6354,10 +6338,6 @@ msgstr ""
 
 #. Default: "The transition you selected does not correspond to the meeting configuration!  Please select a transition using corresponding meeting configuration"
 msgid "transition_not_from_selected_meeting_config"
-msgstr ""
-
-#. Default: "Set here the sequence of transitions in the right order to be triggered on an item for it to be presented to a meeting.  The first transition is the one that starts from the initial state and the last transition should be \"present\".  This is used in several functionnalities like recurring items or items sent to another meeting config that need to be presented automatically."
-msgid "transitions_for_presenting_an_item_descr"
 msgstr ""
 
 #. Default: "Select the transitions triggered on an item that will reinitialize (set back to null) delays started on delay-aware advices.  This will only be the case for not given advices."

--- a/src/imio/pm/locales/locales/en/LC_MESSAGES/PloneMeeting.po
+++ b/src/imio/pm/locales/locales/en/LC_MESSAGES/PloneMeeting.po
@@ -1736,10 +1736,6 @@ msgstr "List of searches to display in the \"todo\" portlet"
 msgid "PloneMeeting_label_toPrint"
 msgstr "To print?"
 
-#. Default: "Transitions for presenting an item"
-msgid "PloneMeeting_label_transitionsForPresentingAnItem"
-msgstr "Transitions for presenting an item"
-
 #. Default: "Transitions that will reinitialize advice delays"
 msgid "PloneMeeting_label_transitionsReinitializingDelays"
 msgstr "Transitions that will reinitialize advice delays"
@@ -3693,10 +3689,6 @@ msgstr "Please choose a file by clicking on the \"Browse\" button."
 msgid "first_linked_vote_used_vote_values_descr"
 msgstr "While using linked vote values, select here values that will be selectable for the first linked vote value"
 
-#. Default: "Please respect order of transitions sequence to present an item, the first given transition is not a transition leaving the item workflow initial state."
-msgid "first_transition_must_leave_wf_initial_state"
-msgstr "Please respect order of transitions sequence to present an item, the first given transition is not a transition leaving the item workflow initial state."
-
 #. Default: "In the application folder of every member, a sub-folder is created for each meeting configuration. The name of this sub-folder is defined here."
 msgid "folder_title_descr"
 msgstr "In the application folder of every member, a sub-folder is created for each meeting configuration. The name of this sub-folder is defined here."
@@ -3728,10 +3720,6 @@ msgstr "E-mail address to use for notifications sent by the application.  If not
 #. Default: "Type here the full name of the functional administrator. If defined, it will be included in the \"from\" part of email notifications sent by the application."
 msgid "functional_admin_name_descr"
 msgstr "Type here the full name of the functional administrator. If defined, it will be included in the \"from\" part of email notifications sent by the application."
-
-#. Default: "Please respect order of transitions sequence to present an item, the given sequence of transitions is wrong."
-msgid "given_wf_path_does_not_lead_to_present"
-msgstr "Please respect order of transitions sequence to present an item, the given sequence of transitions is wrong."
 
 #. Default: "Back to the first elements"
 msgid "goto_first"
@@ -4543,10 +4531,6 @@ msgstr "Search"
 #. Default: "Within every meeting configuration, meetings are numbered sequentially."
 msgid "last_meeting_number_descr"
 msgstr "Within every meeting configuration, meetings are numbered sequentially."
-
-#. Default: "Please respect order of transitions sequence to present an item, the given sequence is not resulting in the \"presented\" state."
-msgid "last_transition_must_result_in_presented_state"
-msgstr "Please respect order of transitions sequence to present an item, the given sequence is not resulting in the \"presented\" state."
 
 #. Default: "Late item"
 msgid "late"
@@ -6270,10 +6254,6 @@ msgstr "WF transition ${state_info} (notify proposing group suffix)."
 #. Default: "The transition you selected does not correspond to the meeting configuration!  Please select a transition using corresponding meeting configuration"
 msgid "transition_not_from_selected_meeting_config"
 msgstr "The transition you selected does not correspond to the meeting configuration!  Please select a transition using corresponding meeting configuration"
-
-#. Default: "Set here the sequence of transitions in the right order to be triggered on an item for it to be presented to a meeting.  The first transition is the one that starts from the initial state and the last transition should be \"present\".  This is used in several functionnalities like recurring items or items sent to another meeting config that need to be presented automatically."
-msgid "transitions_for_presenting_an_item_descr"
-msgstr "Set here the sequence of transitions in the right order to be triggered on an item for it to be presented to a meeting.  The first transition is the one that starts from the initial state and the last transition should be \"present\".  This is used in several functionnalities like recurring items or items sent to another meeting config that need to be presented automatically."
 
 #. Default: "Select the transitions triggered on an item that will reinitialize (set back to null) delays started on delay-aware advices.  This will only be the case for not given advices."
 msgid "transitions_reinitializing_delays_descr"

--- a/src/imio/pm/locales/locales/es/LC_MESSAGES/PloneMeeting.po
+++ b/src/imio/pm/locales/locales/es/LC_MESSAGES/PloneMeeting.po
@@ -1753,10 +1753,6 @@ msgstr ""
 msgid "PloneMeeting_label_toPrint"
 msgstr "¿A imprimir?"
 
-#. Default: "Transitions for presenting an item"
-msgid "PloneMeeting_label_transitionsForPresentingAnItem"
-msgstr ""
-
 #. Default: "Transitions that will reinitialize advice delays"
 msgid "PloneMeeting_label_transitionsReinitializingDelays"
 msgstr ""
@@ -3743,10 +3739,6 @@ msgstr "Por favor elija un archivo haciendo clic en el botón 'Navegar'."
 msgid "first_linked_vote_used_vote_values_descr"
 msgstr ""
 
-#. Default: "Please respect order of transitions sequence to present an item, the first given transition is not a transition leaving the item workflow initial state."
-msgid "first_transition_must_leave_wf_initial_state"
-msgstr ""
-
 #. Default: "In the application folder of every member, a sub-folder is created for each meeting configuration. The name of this sub-folder is defined here."
 #, fuzzy
 msgid "folder_title_descr"
@@ -3782,10 +3774,6 @@ msgstr "En Plone, por defecto, usted puede solamente definir un usuario administ
 #, fuzzy
 msgid "functional_admin_name_descr"
 msgstr "Introduzca aquí el nombre completo del administrador funcional. Si es definido, ese será incluido en la parte del correo 'Desde' de las notificaciones de correo electrónicos enviadas por PloneMeeting (proveídas en los campos anteriores como campos llenadas correctamente)."
-
-#. Default: "Please respect order of transitions sequence to present an item, the given sequence of transitions is wrong."
-msgid "given_wf_path_does_not_lead_to_present"
-msgstr ""
 
 #. Default: "Back to the first elements"
 msgid "goto_first"
@@ -4622,10 +4610,6 @@ msgstr "Búsqueda avanzada"
 #. Default: "Within every meeting configuration, meetings are numbered sequentially."
 msgid "last_meeting_number_descr"
 msgstr "Con cada configuración de reunión, las reuniones son numerados secuencialmente."
-
-#. Default: "Please respect order of transitions sequence to present an item, the given sequence is not resulting in the \"presented\" state."
-msgid "last_transition_must_result_in_presented_state"
-msgstr ""
 
 #. Default: "Late item"
 msgid "late"
@@ -6392,10 +6376,6 @@ msgstr ""
 
 #. Default: "The transition you selected does not correspond to the meeting configuration!  Please select a transition using corresponding meeting configuration"
 msgid "transition_not_from_selected_meeting_config"
-msgstr ""
-
-#. Default: "Set here the sequence of transitions in the right order to be triggered on an item for it to be presented to a meeting.  The first transition is the one that starts from the initial state and the last transition should be \"present\".  This is used in several functionnalities like recurring items or items sent to another meeting config that need to be presented automatically."
-msgid "transitions_for_presenting_an_item_descr"
 msgstr ""
 
 #. Default: "Select the transitions triggered on an item that will reinitialize (set back to null) delays started on delay-aware advices.  This will only be the case for not given advices."

--- a/src/imio/pm/locales/locales/fr/LC_MESSAGES/PloneMeeting.po
+++ b/src/imio/pm/locales/locales/fr/LC_MESSAGES/PloneMeeting.po
@@ -1736,10 +1736,6 @@ msgstr "Recherches à afficher dans le portlet \"À faire\""
 msgid "PloneMeeting_label_toPrint"
 msgstr "À imprimer?"
 
-#. Default: "Transitions for presenting an item"
-msgid "PloneMeeting_label_transitionsForPresentingAnItem"
-msgstr "Succession de transitions à effectuer pour présenter un point"
-
 #. Default: "Transitions that will reinitialize advice delays"
 msgid "PloneMeeting_label_transitionsReinitializingDelays"
 msgstr "Transitions qui remettent à zéro les délais des avis"
@@ -3709,10 +3705,6 @@ msgstr "Veuillez sélectionner un fichier en cliquant sur le bouton \"Parcourir\
 msgid "first_linked_vote_used_vote_values_descr"
 msgstr "Lorsque vous liez des votes entre eux, sélectionnez les valeurs de votes qui pourront être utilisées sur le premier vote lié."
 
-#. Default: "Please respect order of transitions sequence to present an item, the first given transition is not a transition leaving the item workflow initial state."
-msgid "first_transition_must_leave_wf_initial_state"
-msgstr "Respectez bien l'ordre des transitions menant à l'état 'présenté', la première transition renseignée n'est pas une transition qui part de l'état initial du workflow du point."
-
 #. Default: "In the application folder of every member, a sub-folder is created for each meeting configuration. The name of this sub-folder is defined here."
 msgid "folder_title_descr"
 msgstr "Dans le répertoire de chaque utilisateur, un sous-répertoire par configuration de séance est créé. Le nom de ce sous-répertoire se définit ici."
@@ -3744,10 +3736,6 @@ msgstr "Adresse e-mail a utiliser lors de l'envoi des notifications.  Si ce cham
 #. Default: "Type here the full name of the functional administrator. If defined, it will be included in the \"from\" part of email notifications sent by the application."
 msgid "functional_admin_name_descr"
 msgstr "Ecrivez ici le nom complet de l'administrateur fonctionnel. Si défini, il sera utilisé dans le champ \"de\" des courriels de notification envoyés."
-
-#. Default: "Please respect order of transitions sequence to present an item, the given sequence of transitions is wrong."
-msgid "given_wf_path_does_not_lead_to_present"
-msgstr "Respectez bien l'ordre des transitions menant à l'état 'présenté', la succession de transitions renseignée n'est pas valide."
 
 #. Default: "Back to the first elements"
 msgid "goto_first"
@@ -4566,10 +4554,6 @@ msgstr "Recherche"
 #. Default: "Within every meeting configuration, meetings are numbered sequentially."
 msgid "last_meeting_number_descr"
 msgstr "Au sein de chaque configuration, les séances sont numérotées en séquence."
-
-#. Default: "Please respect order of transitions sequence to present an item, the given sequence is not resulting in the \"presented\" state."
-msgid "last_transition_must_result_in_presented_state"
-msgstr "Respectez bien l'ordre des transitions menant à l'état \"présenté\", la succession de transitions renseignée ne mène pas à l'état \"présenté\"."
 
 #. Default: "Late item"
 msgid "late"
@@ -6298,10 +6282,6 @@ msgstr "Transition du WF \"${state_info}\" (prévient le sous-groupe ayant la ma
 #. Default: "The transition you selected does not correspond to the meeting configuration!  Please select a transition using corresponding meeting configuration"
 msgid "transition_not_from_selected_meeting_config"
 msgstr "La transition sélectionnée ne correspond pas au type de séance sélectionné!"
-
-#. Default: "Set here the sequence of transitions in the right order to be triggered on an item for it to be presented to a meeting.  The first transition is the one that starts from the initial state and the last transition should be \"present\".  This is used in several functionnalities like recurring items or items sent to another meeting config that need to be presented automatically."
-msgid "transitions_for_presenting_an_item_descr"
-msgstr "Renseignez la succession de transitions à déclencher dans l'ordre sur un point pour qu'il soit présenté dans une séance.  La première transition est celle qui part de l'état initial du point et la dernière renseignée devrait être \"présenter\".  Cette configuration est nécessaire pour différentes fonctionnalités comme les points récurrents ou les points automatiquement insérés dans une séance lorsqu'ils sont envoyés vers un autre type de séance."
 
 #. Default: "Select the transitions triggered on an item that will reinitialize (set back to null) delays started on delay-aware advices.  This will only be the case for not given advices."
 msgid "transitions_reinitializing_delays_descr"

--- a/src/imio/pm/locales/locales/nl/LC_MESSAGES/PloneMeeting.po
+++ b/src/imio/pm/locales/locales/nl/LC_MESSAGES/PloneMeeting.po
@@ -1744,10 +1744,6 @@ msgstr ""
 msgid "PloneMeeting_label_toPrint"
 msgstr ""
 
-#. Default: "Transitions for presenting an item"
-msgid "PloneMeeting_label_transitionsForPresentingAnItem"
-msgstr ""
-
 #. Default: "Transitions that will reinitialize advice delays"
 msgid "PloneMeeting_label_transitionsReinitializingDelays"
 msgstr ""
@@ -3705,10 +3701,6 @@ msgstr "Gelieve een bestand te kiezen door te klikken op de 'Bladeren' knop."
 msgid "first_linked_vote_used_vote_values_descr"
 msgstr ""
 
-#. Default: "Please respect order of transitions sequence to present an item, the first given transition is not a transition leaving the item workflow initial state."
-msgid "first_transition_must_leave_wf_initial_state"
-msgstr ""
-
 #. Default: "In the application folder of every member, a sub-folder is created for each meeting configuration. The name of this sub-folder is defined here."
 #, fuzzy
 msgid "folder_title_descr"
@@ -3740,10 +3732,6 @@ msgstr ""
 
 #. Default: "Type here the full name of the functional administrator. If defined, it will be included in the \"from\" part of email notifications sent by the application."
 msgid "functional_admin_name_descr"
-msgstr ""
-
-#. Default: "Please respect order of transitions sequence to present an item, the given sequence of transitions is wrong."
-msgid "given_wf_path_does_not_lead_to_present"
 msgstr ""
 
 #. Default: "Back to the first elements"
@@ -4560,10 +4548,6 @@ msgstr ""
 #. Default: "Within every meeting configuration, meetings are numbered sequentially."
 msgid "last_meeting_number_descr"
 msgstr "In iedere vergadering configuratie worden de vergaderingen sequentieel genummerd."
-
-#. Default: "Please respect order of transitions sequence to present an item, the given sequence is not resulting in the \"presented\" state."
-msgid "last_transition_must_result_in_presented_state"
-msgstr ""
 
 #. Default: "Late item"
 msgid "late"
@@ -6310,10 +6294,6 @@ msgstr ""
 
 #. Default: "The transition you selected does not correspond to the meeting configuration!  Please select a transition using corresponding meeting configuration"
 msgid "transition_not_from_selected_meeting_config"
-msgstr ""
-
-#. Default: "Set here the sequence of transitions in the right order to be triggered on an item for it to be presented to a meeting.  The first transition is the one that starts from the initial state and the last transition should be \"present\".  This is used in several functionnalities like recurring items or items sent to another meeting config that need to be presented automatically."
-msgid "transitions_for_presenting_an_item_descr"
 msgstr ""
 
 #. Default: "Select the transitions triggered on an item that will reinitialize (set back to null) delays started on delay-aware advices.  This will only be the case for not given advices."


### PR DESCRIPTION
See #PM-3939